### PR TITLE
feat: changed datastore setter methods to x_entry

### DIFF
--- a/rblxopencloud/__init__.py
+++ b/rblxopencloud/__init__.py
@@ -25,7 +25,7 @@ from typing import Literal
 import requests
 
 VERSION: str = "2.0.0"
-VERSION_INFO: Literal['alpha', 'beta', 'final'] = "beta"
+VERSION_INFO: Literal['alpha', 'beta', 'final'] = "alpha"
 DEBUG: bool = VERSION_INFO == "alpha"
 
 user_agent: str = f"rblx-open-cloud/{VERSION} \

--- a/rblxopencloud/__init__.py
+++ b/rblxopencloud/__init__.py
@@ -25,7 +25,7 @@ from typing import Literal
 import requests
 
 VERSION: str = "2.0.0"
-VERSION_INFO: Literal['alpha', 'beta', 'final'] = "alpha"
+VERSION_INFO: Literal['alpha', 'beta', 'final'] = "beta"
 DEBUG: bool = VERSION_INFO == "alpha"
 
 user_agent: str = f"rblx-open-cloud/{VERSION} \

--- a/rblxopencloud/datastore.py
+++ b/rblxopencloud/datastore.py
@@ -158,7 +158,7 @@ class DataStore():
         cursor_key="cursor", data_key="keys"):
             yield ListedEntry(entry["key"], entry["scope"])
     
-    def get(self, key: str
+    def get_entry(self, key: str
         ) -> tuple[Union[str, dict, list, int, float], EntryInfo]:
         """
         Gets the value of a key in the scope and datastore.
@@ -195,7 +195,7 @@ class DataStore():
             headers["roblox-entry-created-time"],
             headers["roblox-entry-version-created-time"], userids, metadata)
 
-    def set(self, key: str, value: Union[str, dict, list, int, float],
+    def set_entry(self, key: str, value: Union[str, dict, list, int, float],
             users: Optional[list[int]]=None, metadata: dict={},
             exclusive_create: bool=False, previous_version: Optional[str]=None
         ) -> EntryVersion:
@@ -272,7 +272,7 @@ class DataStore():
             self.scope if self.scope else scope
         )
 
-    def increment(self, key: str, delta: Union[int, float],
+    def increment_entry(self, key: str, delta: Union[int, float],
             users: Optional[list[int]]=None, metadata:dict={}
         ) -> tuple[Union[str, dict, list, int, float], EntryInfo]:
         """
@@ -321,7 +321,7 @@ class DataStore():
             headers["roblox-entry-created-time"],
             headers["roblox-entry-version-created-time"], userids, metadata)
     
-    def remove(self, key: str) -> None:
+    def remove_entry(self, key: str) -> None:
         """
         Removes the value of a key from the datastore and scope.
         

--- a/rblxopencloud/http.py
+++ b/rblxopencloud/http.py
@@ -118,7 +118,7 @@ def send_request(method: str, path: str, authorization: Optional[str]=None,
     else:
         body = response.text
 
-    if DEBUG:
+    if DEBUG == True:
         print(f"[DEBUG] {method} /{path} - {response.status_code}\n{body}")
 
     if expected_status:


### PR DESCRIPTION
In this pull request, I've changed the ``get()`` to ``get_entry()`` for extra readability. 