### PR TITLE
rename: data_store -> datastore

### DIFF
--- a/rblxopencloud/experience.py
+++ b/rblxopencloud/experience.py
@@ -529,7 +529,7 @@ class Experience():
         
         return Place(place_id, None, self.__api_key, self)
     
-    def get_data_store(
+    def get_datastore(
             self, name: str, scope: Optional[str] = "global"
         ) -> DataStore:
         """
@@ -546,7 +546,7 @@ class Experience():
         
         return DataStore(name, self, self.__api_key, None, scope)
     
-    def get_ordered_data_store(
+    def get_ordered_datastore(
             self, name: str, scope: Optional[str] = "global"
         ) -> OrderedDataStore:
         """
@@ -563,7 +563,7 @@ class Experience():
         
         return OrderedDataStore(name, self, self.__api_key, scope)
 
-    def list_data_stores(
+    def list_datastores(
             self, prefix: str = "", limit: int = None,
             scope: Optional[str] = "global"
         ) -> Iterable[DataStore]:


### PR DESCRIPTION
This pull request has changed the naming functions of ``data_store`` to it's proper naming convention ``datastore`` 