### PR TITLE
`list_inventory` improvements

### DIFF
--- a/rblxopencloud/user.py
+++ b/rblxopencloud/user.py
@@ -716,7 +716,9 @@ class User(Creator):
 
         if assets is True:
             filter["inventoryItemAssetTypes"] = "*"
-        elif isinstance(assets, list) and assets:  # Do nothing if the list is empty
+        elif (
+            isinstance(assets, list) and assets
+        ):  # Do nothing if the list is empty
             filter_by_type = all(
                 isinstance(asset, InventoryAssetType) for asset in assets
             )
@@ -725,7 +727,7 @@ class User(Creator):
             if not filter_by_type and not filter_by_id:
                 raise ValueError(
                     (
-                        "'assets' must be either a list of InventoryAssetType objects, a list of integers, a boolean, or None."
+                        "'assets' must be either a list of InventoryAssetType objects, a list of integers, a boolean, or None. "
                         "You cannot mix InventoryAssetType objects and integers."
                     )
                 )
@@ -773,11 +775,17 @@ class User(Creator):
             max_yields=limit,
         ):
             if "assetDetails" in entry.keys():
-                yield InventoryAsset(entry["assetDetails"], entry.get("addTime"))
+                yield InventoryAsset(
+                    entry["assetDetails"], entry.get("addTime")
+                )
             elif "badgeDetails" in entry.keys():
-                yield InventoryBadge(entry["badgeDetails"], entry.get("addTime"))
+                yield InventoryBadge(
+                    entry["badgeDetails"], entry.get("addTime")
+                )
             elif "gamePassDetails" in entry.keys():
-                yield InventoryGamePass(entry["gamePassDetails"], entry.get("addTime"))
+                yield InventoryGamePass(
+                    entry["gamePassDetails"], entry.get("addTime")
+                )
             elif "privateServerDetails" in entry.keys():
                 yield InventoryPrivateServer(
                     entry["privateServerDetails"], entry.get("addTime")

--- a/rblxopencloud/user.py
+++ b/rblxopencloud/user.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 
 import datetime
+from collections.abc import Iterable
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union, cast
 
 from dateutil import parser
 
@@ -218,6 +219,8 @@ ASSET_TYPE_STRINGS = {
     "CREATED_PLACE": InventoryAssetType.CreatedPlace,
     "PURCHASED_PLACE": InventoryAssetType.PurchasedPlace,
 }
+
+ASSET_TYPE_STRINGS_REVERSE = {v: k for k, v in ASSET_TYPE_STRINGS.items()}
 
 
 class InventoryItemState(Enum):
@@ -663,9 +666,9 @@ class User(Creator):
 
     def list_inventory(
         self,
-        limit: int = None,
+        limit: Optional[int] = None,
         only_collectibles: bool = False,
-        assets: Union[list[InventoryAssetType], list[int], bool] = None,
+        assets: Optional[Union[list[InventoryAssetType], list[int], bool]] = None,
         badges: Union[list[int], bool] = False,
         game_passes: Union[list[int], bool] = False,
         private_servers: Union[list[int], bool] = False,
@@ -678,17 +681,17 @@ class User(Creator):
         ]
     ]:
         """
-        Interates [`InventoryItem`][rblxopencloud.InventoryItem] for items in \
+        Iterates [`InventoryItem`][rblxopencloud.InventoryItem] for items in \
         the user's inventory. If `only_collectibles`, `assets`, `badges`, \
         `game_passes`, and `private_servers` are `False`, then all inventory \
         items are returned.
-        
+
         Args:
-            limit (bool): The maximum number of inventory items to iterate. \
+            limit (Optional[int]): The maximum number of inventory items to iterate. \
             This can be `None` to return all items.
-            only_collectibles (bool): Wether the only inventory assets \
+            only_collectibles (bool): Whether the only inventory assets \
             returned are collectibles (limited items).
-            assets (Union[list[InventoryAssetType], list[int], bool]): If \
+            assets (Optional[Union[list[InventoryAssetType], list[int], bool]]): If \
             `True`, then it will return all assets, if it is a list of IDs, \
             it will only return assets with the provided IDs, and if it is a \
             list of [`InventoryAssetType`][rblxopencloud.InventoryAssetType] \
@@ -713,35 +716,45 @@ class User(Creator):
 
         if assets is True:
             filter["inventoryItemAssetTypes"] = "*"
-        elif type(assets) == list and isinstance(
-            assets[0], InventoryAssetType
-        ):
+        elif isinstance(assets, list) and assets:  # Do nothing if the list is empty
+            filter_by_type = all(
+                isinstance(asset, InventoryAssetType) for asset in assets
+            )
+            filter_by_id = all(isinstance(asset, int) for asset in assets)
 
-            asset_types = []
-            for asset_type in assets:
-                asset_types.append(
-                    list(ASSET_TYPE_STRINGS.keys())[
-                        list(ASSET_TYPE_STRINGS.values()).index(asset_type)
-                    ]
+            if not filter_by_type and not filter_by_id:
+                raise ValueError(
+                    (
+                        "'assets' must be either a list of InventoryAssetType objects, a list of integers, a boolean, or None."
+                        "You cannot mix InventoryAssetType objects and integers."
+                    )
                 )
 
-            filter["inventoryItemAssetTypes"] = ",".join(asset_types)
-        elif type(assets) == list:
-            filter["assetIds"] = ",".join([str(id) for id in assets])
+            if filter_by_type:
+                asset_types: list[str] = []
+                # this is validated by the above code, but the typechecker doesn't know that, so we cast
+                assets = cast(list[InventoryAssetType], assets)
+                for asset_type in assets:
+                    asset_types.append(ASSET_TYPE_STRINGS_REVERSE[asset_type])
+                filter["inventoryItemAssetTypes"] = ",".join(asset_types)
+            elif filter_by_id:
+                # this is validated by the above code, but the typechecker doesn't know that, so we cast
+                assets = cast(list[int], assets)
+                filter["assetIds"] = ",".join([str(id) for id in assets])
 
         if badges is True:
             filter["badges"] = "true"
-        elif type(badges) == list:
+        elif isinstance(badges, list):
             filter["badgeIds"] = ",".join([str(id) for id in badges])
 
         if game_passes is True:
             filter["gamePasses"] = "true"
-        elif type(game_passes) == list:
+        elif isinstance(game_passes, list):
             filter["gamePassIds"] = ",".join([str(id) for id in game_passes])
 
         if private_servers is True:
             filter["privateServers"] = "true"
-        elif type(badges) == list:
+        elif isinstance(private_servers, list):
             filter["privateServerIds"] = ",".join(
                 [str(private_server) for private_server in private_servers]
             )
@@ -760,17 +773,11 @@ class User(Creator):
             max_yields=limit,
         ):
             if "assetDetails" in entry.keys():
-                yield InventoryAsset(
-                    entry["assetDetails"], entry.get("addTime")
-                )
+                yield InventoryAsset(entry["assetDetails"], entry.get("addTime"))
             elif "badgeDetails" in entry.keys():
-                yield InventoryBadge(
-                    entry["badgeDetails"], entry.get("addTime")
-                )
+                yield InventoryBadge(entry["badgeDetails"], entry.get("addTime"))
             elif "gamePassDetails" in entry.keys():
-                yield InventoryGamePass(
-                    entry["gamePassDetails"], entry.get("addTime")
-                )
+                yield InventoryGamePass(entry["gamePassDetails"], entry.get("addTime"))
             elif "privateServerDetails" in entry.keys():
                 yield InventoryPrivateServer(
                     entry["privateServerDetails"], entry.get("addTime")

--- a/rblxopencloudasync/user.py
+++ b/rblxopencloudasync/user.py
@@ -664,7 +664,9 @@ class User(Creator):
 
         if assets is True:
             filter["inventoryItemAssetTypes"] = "*"
-        elif isinstance(assets, list) and assets:  # Do nothing if the list is empty
+        elif (
+            isinstance(assets, list) and assets
+        ):  # Do nothing if the list is empty
             filter_by_type = all(
                 isinstance(asset, InventoryAssetType) for asset in assets
             )
@@ -673,7 +675,7 @@ class User(Creator):
             if not filter_by_type and not filter_by_id:
                 raise ValueError(
                     (
-                        "'assets' must be either a list of InventoryAssetType objects, a list of integers, a boolean, or None."
+                        "'assets' must be either a list of InventoryAssetType objects, a list of integers, a boolean, or None. "
                         "You cannot mix InventoryAssetType objects and integers."
                     )
                 )
@@ -720,11 +722,17 @@ class User(Creator):
             expected_status=[200],
         ):
             if "assetDetails" in entry.keys():
-                yield InventoryAsset(entry["assetDetails"], entry.get("addTime"))
+                yield InventoryAsset(
+                    entry["assetDetails"], entry.get("addTime")
+                )
             elif "badgeDetails" in entry.keys():
-                yield InventoryBadge(entry["badgeDetails"], entry.get("addTime"))
+                yield InventoryBadge(
+                    entry["badgeDetails"], entry.get("addTime")
+                )
             elif "gamePassDetails" in entry.keys():
-                yield InventoryGamePass(entry["gamePassDetails"], entry.get("addTime"))
+                yield InventoryGamePass(
+                    entry["gamePassDetails"], entry.get("addTime")
+                )
             elif "privateServerDetails" in entry.keys():
                 yield InventoryPrivateServer(
                     entry["privateServerDetails"], entry.get("addTime")

--- a/rblxopencloudasync/user.py
+++ b/rblxopencloudasync/user.py
@@ -363,7 +363,7 @@ class InventoryPrivateServer(InventoryItem):
     """
 
     def __init__(self, data, add_time: Optional[str]) -> None:
-        super().__init__(data["privateServerId"])
+        super().__init__(data["privateServerId"], add_time)
 
     def __repr__(self) -> str:
         return f"<rblxopencloud.InventoryPrivateServer id={self.id}>"


### PR DESCRIPTION
This commit fixes a couple of issues with the `User.list_inventory` method, both for the sync and async versions of this library.

Firstly, it corrects the async method's return value typehint to be `AsyncGenerator[Union[...], None]` instead of the previous `AsyncGenerator[Any, Union[...]]`.

It also corrects a couple of other typehinting issues, and updates the docstrings to align with the methods' real signature.

All instances of `type() ==` being used for instance checks have been replaced with `isinstance`. I don't think the old behavior caused bugs, but best practice is to use isinstance. See [`type-comparison` (E721)](https://docs.astral.sh/ruff/rules/type-comparison/) for more info on this.

A bug where the `badges` list was being used alongisde `private_server` instead of the proper `private_server` list has also been fixed.

The processing for the `assets` argument has been rewritten, and is more fault-tolerant now. For instance, an empty list being passed in the `assets` argument will no longer cause an error to be thrown, instead it'll be silently ignored. A reverse mapping of `ASSET_TYPE_STRINGS` has been added to help simplify this logic. It is probably a bit slower, though, as it has to iterate the list a couple more times to figure out how to apply its contents. Some casts were required here to get everything to clear my typechecker, but I don't think it should cause any issues. I'd double check, whoever's reviewing this, just to be sure.

As an addendum, regarding `assets`, I would make it take two separate `assets` and `asset_types` arguments instead of making the same argument do both. This would reduce performance overhead with larger lists, and would make the behavior clearer. I didn't do that here though, because it'd be a breaking change for existing users who use `assets` to filter by asset type.